### PR TITLE
Update pytest to latest version, remove unecessary dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,5 @@
-attrs==21.2.0
-autopep8==1.5.7
-iniconfig==1.1.1
-packaging==21.0
-pluggy==1.0.0
-py==1.11.0
-pycodestyle==2.7.0
-pyparsing==2.4.7
-pytest==7.2.2
-toml==0.10.2
+iniconfig==2.0.0
+packaging==23.1
+pluggy==1.3.0
+pytest==7.4.2
 wonderwords==2.2.0


### PR DESCRIPTION
Update to latest version of pytest (7.4.2). Wonderwords has not been updated since Feb 2021 so no changes there, but we may want to consider swapping this out for a package that is still being maintained. 

- Solution branch for testing: https://github.com/AdaGold/snowbug/tree/kelsey_solution_updated_pytest
- When we've merged in the changes, I plan to remove the solution branches from this repo in favor of the AdaAnswers repo: https://github.com/AdaAnswers/snowbug. The solution branch has a new section in the README that covers where the bugs are so we can keep that info with the solution.
